### PR TITLE
fix: update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,4 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'wednesday'
+      interval: 'monthly'

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## What?

- upgrading checkout action to v3
- dependabot setting interval to monthly

## Why?

- github is sunsetting NodeJS@12 based actions
- too many PRs from dependabot on same item, monthly should reduce this

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A
