### PR TITLE
fix: revert widget css to fix cache/hash issue

### DIFF
--- a/apps/landing/src/renderer/_default.page.server.tsx
+++ b/apps/landing/src/renderer/_default.page.server.tsx
@@ -42,8 +42,8 @@ async function render(pageContext: PageContextServer) {
     <div id="page-view">${dangerouslySkipEscape(pageHtml)}</div>
     <script>
       window.SWU_CONFIG = {
-        "style": "white",
-        "placement": "top-right",
+        "style": "blue",
+        "placement": "bottom-right",
         "charity_selections": [
           "razom",
           "new-ukraine",

--- a/apps/widget/src/components/Widget/styles.module.scss
+++ b/apps/widget/src/components/Widget/styles.module.scss
@@ -12,7 +12,7 @@
   cursor: pointer;
 
   &.collapsed {
-    max-width: 86px;
+    max-width: 86;
   }
 
   &.animated {
@@ -135,10 +135,6 @@
     overflow: hidden;
     border-radius: 50%;
     border: 3px solid #fff;
-
-    &:empty {
-      display: block !important;
-    }
 
     &::before {
       content: '';


### PR DESCRIPTION
## What?

Revert css fix for shopify

## Why?

Css hash / cache breaking the widget on main site

## Screenshots/Screen Recordings

N/A

## Testing/Proof

N/A