### PR TITLE
feat(components): add support Ukraine section

### DIFF
--- a/apps/landing/src/components/Layout.tsx
+++ b/apps/landing/src/components/Layout.tsx
@@ -5,7 +5,7 @@ import { breakpoints } from '../helpers';
 interface SectionProps {
   alignItems?: CSSProperties['alignItems'];
   justifyContent?: CSSProperties['justifyContent'];
-  background?: 'light' | 'primary' | 'gray' | 'dark';
+  background?: 'light' | 'primary' | 'gray' | 'dark' | 'blue';
   display?: string;
   paddingX?: number;
   paddingY?: number;
@@ -51,6 +51,9 @@ export const Section = styled.section<SectionProps>`
       switch (background) {
         case 'primary':
           return 'linear-gradient(115.91deg, #0D52FF 8.17%, #4100A3 91.36%)';
+
+        case 'blue':
+          return 'linear-gradient(120deg, #4100A3 8.72%, #03EADA 95.4%)';
 
         case 'gray':
           return '#EDEFF3';

--- a/apps/landing/src/components/Layout.tsx
+++ b/apps/landing/src/components/Layout.tsx
@@ -14,6 +14,7 @@ interface SectionProps {
 interface ContainerProps {
   alignItems?: CSSProperties['alignItems'];
   flexDirection?: CSSProperties['flexDirection'];
+  flexWrap?: CSSProperties['flexWrap'];
   justifyContent?: CSSProperties['justifyContent'];
   paddingX?: number;
   paddingY?: number;
@@ -97,6 +98,12 @@ export const Container = styled.div<ContainerProps>`
     justifyContent &&
     css`
       justify-content: ${justifyContent};
+    `}
+
+  ${({ flexWrap }) =>
+    flexWrap &&
+    css`
+      flex-wrap: ${flexWrap};
     `}
 
   ${({ paddingX = 0, paddingY = 0 }) => css`

--- a/apps/landing/src/pages/index.page.tsx
+++ b/apps/landing/src/pages/index.page.tsx
@@ -9,6 +9,7 @@ import {
   HowItWorks,
   LogoPanel,
   Stats,
+  Support,
   Team,
 } from '../sections';
 
@@ -25,6 +26,7 @@ function Page() {
       <AddWidget />
       <Charities />
       <Team />
+      <Support />
       <Faq />
       <Contacts />
       <LogoPanel />

--- a/apps/landing/src/sections/Support.tsx
+++ b/apps/landing/src/sections/Support.tsx
@@ -1,0 +1,71 @@
+import styled from 'styled-components';
+
+import { ButtonLink, Container, H2, H3, Item, Paragraph, Section } from '../components';
+import { breakpoints } from '../helpers';
+
+const StyledParagraph = styled(Paragraph)`
+  margin-bottom: 3rem;
+
+  ${breakpoints.desktop} {
+    margin-bottom: 6rem;
+  }
+`;
+
+const StyledItem = styled.div`
+  background: #000;
+  padding: 3rem 1.5rem;
+  text-align: center;
+
+  ${H3} {
+    margin-bottom: 3rem;
+  }
+
+  ${ButtonLink} {
+    background-image: linear-gradient(to bottom right, #ffd500 50%, #fff 0);
+    max-width: 50rem;
+    width: 100%;
+  }
+
+  ${breakpoints.desktop} {
+    padding: 5rem 4rem;
+  }
+`;
+
+export const Support = () => (
+  <Section background="blue" id="support">
+    <H2 color="light" margin="0 0 3rem" textAlign="center">
+      Support our colleagues
+    </H2>
+    <StyledParagraph color="light" margin="0 0 6rem" size={2} textAlign="center" weight={300}>
+      Select option to support our colleagues that defends Ukraine!
+    </StyledParagraph>
+    <Container>
+      <Item flexBasis="50%" flexGrow={1}>
+        <StyledItem>
+          <H3 color="light">2000</H3>
+          <ButtonLink
+            href="https://pay.fondy.eu/merchants/9989e4238d2bca3292873fb855506edfa149a3c7/default/index.html?button=692f94ed19eb75fbff4622417b4c1c3bd3ba25d3"
+            rel="noreferrer"
+            target="_blank"
+            variant="light"
+          >
+            Support
+          </ButtonLink>
+        </StyledItem>
+      </Item>
+      <Item flexBasis="50%" flexGrow={1}>
+        <StyledItem>
+          <H3 color="light">Custom</H3>
+          <ButtonLink
+            href="https://pay.fondy.eu/merchants/9989e4238d2bca3292873fb855506edfa149a3c7/default/index.html?button=3d8d9d715ed9d4e4e93ff5e18f3049b10d21082b"
+            rel="noreferrer"
+            target="_blank"
+            variant="light"
+          >
+            Support
+          </ButtonLink>
+        </StyledItem>
+      </Item>
+    </Container>
+  </Section>
+);

--- a/apps/landing/src/sections/Support.tsx
+++ b/apps/landing/src/sections/Support.tsx
@@ -39,10 +39,10 @@ export const Support = () => (
     <StyledParagraph color="light" margin="0 0 6rem" size={2} textAlign="center" weight={300}>
       Select option to support our colleagues that defends Ukraine!
     </StyledParagraph>
-    <Container>
-      <Item flexBasis="50%" flexGrow={1}>
+    <Container flexWrap="wrap">
+      <Item flexBasis="31%">
         <StyledItem>
-          <H3 color="light">2000</H3>
+          <H3 color="light">2000 UAH</H3>
           <ButtonLink
             href="https://pay.fondy.eu/merchants/9989e4238d2bca3292873fb855506edfa149a3c7/default/index.html?button=692f94ed19eb75fbff4622417b4c1c3bd3ba25d3"
             rel="noreferrer"
@@ -53,7 +53,31 @@ export const Support = () => (
           </ButtonLink>
         </StyledItem>
       </Item>
-      <Item flexBasis="50%" flexGrow={1}>
+      <Item flexBasis="31%">
+        <StyledItem>
+          <H3 color="light">3000 UAH</H3>
+          <ButtonLink href="#" rel="noreferrer" target="_blank" variant="light">
+            Support
+          </ButtonLink>
+        </StyledItem>
+      </Item>
+      <Item flexBasis="31%">
+        <StyledItem>
+          <H3 color="light">4000 UAH</H3>
+          <ButtonLink href="#" rel="noreferrer" target="_blank" variant="light">
+            Support
+          </ButtonLink>
+        </StyledItem>
+      </Item>
+      <Item flexBasis="31%">
+        <StyledItem>
+          <H3 color="light">5000 UAH</H3>
+          <ButtonLink href="#" rel="noreferrer" target="_blank" variant="light">
+            Support
+          </ButtonLink>
+        </StyledItem>
+      </Item>
+      <Item flexBasis="31%">
         <StyledItem>
           <H3 color="light">Custom</H3>
           <ButtonLink

--- a/apps/landing/src/sections/index.ts
+++ b/apps/landing/src/sections/index.ts
@@ -8,3 +8,4 @@ export * from './Charities';
 export * from './Team';
 export * from './Faq';
 export * from './Contacts';
+export * from './Support';


### PR DESCRIPTION
## What?
Add `Support` section as on screenshots below.

<img width="1512" alt="Screenshot 2023-12-20 at 12 56 08" src="https://github.com/bigcommerce/stand-with-ukraine-frontend/assets/9980803/dc4baf26-a962-4a8d-a4eb-12cfc031eb62">
<img width="391" alt="Screenshot 2023-12-20 at 12 34 35" src="https://github.com/bigcommerce/stand-with-ukraine-frontend/assets/9980803/b5f5b49f-d197-4501-bd65-d63d30adc448">

## Testing/Proof
Locally.
