### PR TITLE
chore(common): add additional support content

### DIFF
--- a/apps/landing/src/sections/Contacts.tsx
+++ b/apps/landing/src/sections/Contacts.tsx
@@ -47,6 +47,7 @@ const StyledLink = styled.a`
   font-size: 1.7rem;
   font-weight: 100;
   line-height: 2.7rem;
+  margin-bottom: 2rem;
   text-decoration: none;
 
   img {
@@ -180,6 +181,13 @@ export const Contacts = () => {
             Get support
             <img alt="External link icon" className="lazyload" data-src={OpenInNewWindowSVG} />
           </StyledLink>
+          <StyledParagraph color="light" size={1.7}>
+            Our emails:
+            <br />
+            bohdan.hodzenko@bigcommerce.com
+            <br />
+            kristina.pototska@bigcommerce.com
+          </StyledParagraph>
         </Item>
         <StyledForm flexBasis="50%">
           <H4>Contact form</H4>

--- a/apps/landing/src/sections/Support.tsx
+++ b/apps/landing/src/sections/Support.tsx
@@ -5,6 +5,7 @@ import { breakpoints } from '../helpers';
 
 const StyledParagraph = styled(Paragraph)`
   margin-bottom: 3rem;
+  line-height: 1.6;
 
   ${breakpoints.desktop} {
     margin-bottom: 6rem;
@@ -38,6 +39,8 @@ export const Support = () => (
     </H2>
     <StyledParagraph color="light" margin="0 0 6rem" size={2} textAlign="center" weight={300}>
       Select option to support our colleagues that defends Ukraine!
+      <br />
+      To cancel your support send a message via Contract us form below.
     </StyledParagraph>
     <Container flexWrap="wrap">
       <Item flexBasis="31%">


### PR DESCRIPTION
## What?
Add additional support content.

## Why?
It will allow us to register support subscriptions.

## Screenshots/Screen Recordings
<img width="1256" alt="Screenshot 2023-12-25 at 17 45 52" src="https://github.com/bigcommerce/stand-with-ukraine-frontend/assets/9980803/e8c83cac-af0b-4b4e-ac70-604706384f16">
<img width="1249" alt="Screenshot 2023-12-25 at 17 46 01" src="https://github.com/bigcommerce/stand-with-ukraine-frontend/assets/9980803/8ca307b3-efc4-40fd-b7aa-7c58354a9d32">


## Testing/Proof
Locally
