### PR TITLE
Use base URL for doc links.

### DIFF
--- a/apps/landing/src/sections/DocsPanel.tsx
+++ b/apps/landing/src/sections/DocsPanel.tsx
@@ -23,13 +23,14 @@ interface DocLinks {
   };
 }
 
+const baseUrl = import.meta.env.BASE_URL;
 const docLinks: DocLinks = {
   'en-US': {
-    href: '/assets/docs/landing/Public offer to make a voluntary charitable donation.pdf',
+    href: `${baseUrl}/assets/docs/landing/Public offer to make a voluntary charitable donation.pdf`,
     content: 'Public offer to make a voluntary charitable donation',
   },
   'uk-UA': {
-    href: '/assets/docs/landing/Публічна оферта про надання добровільної благодійної пожертви.pdf',
+    href: `${baseUrl}/assets/docs/landing/Публічна оферта про надання добровільної благодійної пожертви.pdf`,
     content: 'Публічна оферта про надання добровільної благодійної пожертви',
   },
 };


### PR DESCRIPTION
## What? / Why?

Use base URL for doc links.


## Screenshots/Screen Recordings / Testing/Proof
1. open http://localhost:3002/landing
2. navigate to bottom
3. click link 

![image](https://github.com/bigcommerce/stand-with-ukraine-frontend/assets/425208/2db7a3e8-f883-479d-ac05-497b2cef25a4)
